### PR TITLE
Add example to use Scope factory to replace builder as a future reference.

### DIFF
--- a/samples/sample/src/test/java/motif/sample/app/ParentScope.java
+++ b/samples/sample/src/test/java/motif/sample/app/ParentScope.java
@@ -3,4 +3,8 @@ package motif.sample.app;
 @motif.Scope
 interface ParentScope {
     ChildScope childScope();
+
+    interface Dependencies {
+        String name();
+    }
 }

--- a/samples/sample/src/test/java/motif/sample/app/ParentScopeBuilder.java
+++ b/samples/sample/src/test/java/motif/sample/app/ParentScopeBuilder.java
@@ -1,6 +1,6 @@
 package motif.sample.app;
 
-@motif.Scope
-public interface ParentScopeBuilder {
-    ParentScope create(@motif.Expose String name);
+import motif.ScopeFactory;
+
+public class ParentScopeBuilder extends motif.ScopeFactory<ParentScope, ParentScope.Dependencies> {
 }

--- a/samples/sample/src/test/java/motif/sample/app/Test.java
+++ b/samples/sample/src/test/java/motif/sample/app/Test.java
@@ -22,7 +22,7 @@ public class Test {
 
     @org.junit.Test
     public void run() {
-        ParentScope parentScope = new ParentScopeBuilderImpl().create("foo");
+        ParentScope parentScope = new ParentScopeBuilder().create(() -> "foo");
         assertThat(parentScope.childScope().parentName()).isEqualTo("foo");
     }
 }


### PR DESCRIPTION
Just add an example to demonstrate the difference between legacy approach of creating ParentScope and new approach of creating ParentScope.